### PR TITLE
feat(headerCellFilter): add support to 'headerCellFilter' option

### DIFF
--- a/src/UiGridAutoFitColumnsService.ts
+++ b/src/UiGridAutoFitColumnsService.ts
@@ -102,7 +102,13 @@ export class UiGridAutoFitColumnsService {
 
             if (column.colDef.enableColumnAutoFit) {
                 const columnKey = column.field || column.name;
-                optimalWidths[columnKey] = Measurer.measureRoundedTextWidth(column.displayName, this.gridMetrics.getHeaderFont()) + this.gridMetrics.getHeaderButtonsWidth();
+
+                let headerText = column.displayName;
+
+                if (!!column.colDef.headerCellFilter) {
+                    headerText = this.getFilteredValue(headerText, column.colDef.headerCellFilter);
+                }
+                optimalWidths[columnKey] = Measurer.measureRoundedTextWidth(headerText, this.gridMetrics.getHeaderFont()) + this.gridMetrics.getHeaderButtonsWidth();
 
                 rows.forEach((row) => {
                     let cellText = get(row.entity, columnKey);


### PR DESCRIPTION
The same way this plugin support 'cellFilter' you can support 'headerCellFilter' with this simple pr. I need it to translate using angular-translate.

Thank you for the awesome plugin!