### PR TITLE
feat(autoFitGridWidth): columns grow or shrink to fit every pixel of the grid/canvas width.

### DIFF
--- a/src/UiGridAutoFitColumnsService.ts
+++ b/src/UiGridAutoFitColumnsService.ts
@@ -87,16 +87,17 @@ export class UiGridAutoFitColumnsService {
     }
 
     columnsProcessor(renderedColumnsToProcess?: Array<IExtendedGridColumn>, rows?: Array<uiGrid.IGridRow>) {
-        if (!rows.length) {
+        if (!rows.length || renderedColumnsToProcess.length === 0) {
             return renderedColumnsToProcess;
         }
         // TODO: respect existing colDef options
         // if (col.colDef.enableColumnAutoFitting === false) return;
 
+        let gridWidth = renderedColumnsToProcess[0].grid.gridWidth;
         let optimalWidths: {
             [name: string]: number
         } = {};
-
+        let columnsWidth = 0;
 
         renderedColumnsToProcess.forEach(column => {
 
@@ -120,9 +121,20 @@ export class UiGridAutoFitColumnsService {
                 });
 
                 column.colDef.width = optimalWidths[columnKey] + this.gridMetrics.getPadding() + this.gridMetrics.getBorder();
+                columnsWidth += column.colDef.width;
+            } else {
+                gridWidth -= column.colDef.width;
+            }
+        });
+
+        const multiplier = gridWidth / columnsWidth;
+        renderedColumnsToProcess.forEach(function (column) {
+            if (column.colDef.enableColumnAutoFit) {
+                column.colDef.width = Math.round(column.colDef.width * multiplier);
                 column.updateColumnDef(column.colDef, false);
             }
         });
+
         return renderedColumnsToProcess;
     }
 


### PR DESCRIPTION
With this change the plugin is able to adapt columns' width to fit the canvas width. If the canvas is larger than the optimized columns' size, the white space is divided equally between the columns. If the canvas is smaller than the optimized columns' size, these are reduced equally to fit only the space available.

You can create columns with a fixed width (which don't grow or shrink) this way:
```
{
    name: 'columnName',
    field: 'columnField',
    displayName: 'my column name',
    width: 50, // Fixed width
    enableColumnAutoFit: false, // Don't grow or shrink
}
```

If you want I can add a parameter to choose the behaviour to use for every table.